### PR TITLE
Fix types issue with Applitools Eyes SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,19 +53,29 @@
       }
     },
     "@applitools/eyes-webdriverio": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@applitools/eyes-webdriverio/-/eyes-webdriverio-5.14.0.tgz",
-      "integrity": "sha512-+8buWQ7kG+belrv0wZmBs2iM3JIKibiDecbA05g9pzE1t56HEgpSrZYTryPiEUYJKTQADofHzkKN5U+32BHBgg==",
+      "version": "5.18.4",
+      "resolved": "https://registry.npmjs.org/@applitools/eyes-webdriverio/-/eyes-webdriverio-5.18.4.tgz",
+      "integrity": "sha512-3ipCbzoxGqCu3tv6ca03Qg22SrrqTIe7T4i1b1RWhYP/X7hYI3tBjvj05GaFYbYS+7KugDtBiPqBuVbJbuCWog==",
       "dev": true,
       "requires": {
-        "@applitools/eyes-sdk-core": "11.0.9",
-        "@applitools/visual-grid-client": "14.4.8"
+        "@applitools/eyes-sdk-core": "11.3.7",
+        "@applitools/visual-grid-client": "14.5.11"
       },
       "dependencies": {
+        "@applitools/dom-snapshot": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/@applitools/dom-snapshot/-/dom-snapshot-3.7.1.tgz",
+          "integrity": "sha512-VRH752F2hvXiMT1xfM/ktQ133SQ0MA8TKuhztjB0G9936sGBlNKKe+wx+lfqL3soa60RhND/LIwnubkmB4r21Q==",
+          "dev": true,
+          "requires": {
+            "@applitools/functional-commons": "1.5.4",
+            "css-tree": "^1.0.0-alpha.39"
+          }
+        },
         "@applitools/eyes-sdk-core": {
-          "version": "11.0.9",
-          "resolved": "https://registry.npmjs.org/@applitools/eyes-sdk-core/-/eyes-sdk-core-11.0.9.tgz",
-          "integrity": "sha512-9G7yrYE1TjoPbHyol6VCEfHVTHyECCFVi5aJTr6cHspaNQf7RcCO6Exk37O58SdMq/2PapVkVjygj8kizdB2gA==",
+          "version": "11.3.7",
+          "resolved": "https://registry.npmjs.org/@applitools/eyes-sdk-core/-/eyes-sdk-core-11.3.7.tgz",
+          "integrity": "sha512-jvMp9o71Xvztbn73M/k5i34zSINjSkRHFgc5ROHx6xE9yfnRsJ/8rrvjkQYr9JUW+DO0X8+Q0M2P+MHW2QULdg==",
           "dev": true,
           "requires": {
             "@applitools/dom-capture": "7.2.4",
@@ -82,13 +92,13 @@
           }
         },
         "@applitools/visual-grid-client": {
-          "version": "14.4.8",
-          "resolved": "https://registry.npmjs.org/@applitools/visual-grid-client/-/visual-grid-client-14.4.8.tgz",
-          "integrity": "sha512-EkcteSs8PGv75mUpfDvQbj95zwNss+LHbC7tsMQHP3qs1y5uiqAVYj97cmOjl3+/6UHZ4O62m/zGomPa3hQMnw==",
+          "version": "14.5.11",
+          "resolved": "https://registry.npmjs.org/@applitools/visual-grid-client/-/visual-grid-client-14.5.11.tgz",
+          "integrity": "sha512-8uM/wD47N/EzTbkjN9Gr7rRCoDWKOd6wr5/WXYydYlnaGi9mxPr4uislNtQ+OVLx+dqxLJQU+3N/PQxWYSaSpw==",
           "dev": true,
           "requires": {
-            "@applitools/dom-snapshot": "3.5.3",
-            "@applitools/eyes-sdk-core": "11.0.9",
+            "@applitools/dom-snapshot": "3.7.1",
+            "@applitools/eyes-sdk-core": "11.3.7",
             "@applitools/feature-flags": "2.1.1",
             "@applitools/functional-commons": "1.5.4",
             "@applitools/http-commons": "2.3.12",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "devDependencies": {
     "@applitools/eyes-selenium": "^4.33.31",
-    "@applitools/eyes-webdriverio": "^5.14.0",
+    "@applitools/eyes-webdriverio": "^5.18.4",
     "@types/jasmine": "^3.5.10",
     "@wdio/allure-reporter": "^6.0.14",
     "@wdio/browserstack-service": "^6.0.17",

--- a/src/specs/category-applitools.spec.ts
+++ b/src/specs/category-applitools.spec.ts
@@ -25,7 +25,7 @@ describe('category-tests ', () => {
 
 
   afterEach( () => {
-    if (browser.call(() =>  eyes.getIsOpen() )) {
+    if (browser.call(async () =>  eyes.getIsOpen() )) {
       browser.call(() => eyes.close(false));
     }
   });

--- a/src/specs/charleston-applitools.spec.ts
+++ b/src/specs/charleston-applitools.spec.ts
@@ -16,7 +16,7 @@ describe('charleston-tests ', () => {
   });
 
   afterEach( () => {
-    if (browser.call(() =>  eyes.getIsOpen() )) {
+    if (browser.call(async () =>  eyes.getIsOpen() )) {
       browser.call(() => eyes.close(false));
     }
   });

--- a/src/specs/product-applitools.spec.ts
+++ b/src/specs/product-applitools.spec.ts
@@ -24,7 +24,7 @@ describe('product-tests', () => {
   });
 
   afterEach( () => {
-    if (browser.call(() =>  eyes.getIsOpen() )) {
+    if (browser.call(async () =>  eyes.getIsOpen() )) {
       browser.call(() => eyes.close(false));
     }
   });

--- a/src/specs/versus-applitools.spec.ts
+++ b/src/specs/versus-applitools.spec.ts
@@ -32,7 +32,7 @@ describe('versus-page-tests :: ', () => {
   });
 
   afterEach( () => {
-    if (browser.call(() =>  eyes.getIsOpen() )) {
+    if (browser.call(async () =>  eyes.getIsOpen() )) {
       browser.call(() => eyes.close(false));
     }
   });


### PR DESCRIPTION
The new version of `@applitools/eyes-webdriverio` - `5.18.4` - fixes all typing issues that arose from introducing types to the SDK.
The final change needed is to use `async` for the return type from `browser.call` to be a Promise.